### PR TITLE
Update python dependencies (to unblock build).

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 # Apache OpenWhisk Docker Runtime Container
 
+## next release
+Changes:
+  - Update Python dependencies
+
 ## 1.15.0
   - Update base python image to `python:3.11-alpine`
   - Update python dependacies

--- a/core/actionProxy/Dockerfile
+++ b/core/actionProxy/Dockerfile
@@ -24,7 +24,7 @@ RUN apk upgrade --update \
   && update-ca-certificates \
   && apk add --no-cache --virtual .build-deps bzip2-dev g++ libc-dev \
   && pip install --upgrade pip setuptools six \
-  && pip install --no-cache-dir gevent==22.10.2 flask==2.2.3 greenlet==2.0.2\
+  && pip install --no-cache-dir gevent==23.9.1 flask==3.0.0 greenlet==3.0.0\
   && apk del .build-deps
 
 ENV FLASK_PROXY_PORT 8080


### PR DESCRIPTION
The current github actions fail due to updates of subsequent depending python modules on pypi.org.

These changes required to update the pinned dependencies (flask==2.2.3 -> flask==3.0.0) to unblock the build.
Also updated the other python dependencies to get latest security fixes from there, too.
